### PR TITLE
fix/job-board-mobi-collapsible-div

### DIFF
--- a/src/components/MainJobBoard/MainJobBoard.scss
+++ b/src/components/MainJobBoard/MainJobBoard.scss
@@ -43,7 +43,7 @@ $nunito: "Nunito";
 @media only screen and (max-width: 800px) {
   .all-jobs {
     width: 100%;
-    height: 10vh;
+    min-height: 10vh;
     margin: 0 auto;
     display: flex;
     padding: 10px 0;

--- a/src/components/MainJobBoard/MainJobBoardItem.js
+++ b/src/components/MainJobBoard/MainJobBoardItem.js
@@ -7,9 +7,9 @@ const MainJobBoardItem = ({ item }) => {
 
   return (
     <React.Fragment>
-      <div className="all-jobs" onClick={handleDropdown}>
+      <div className="all-jobs">
         {/* <h1>{item.id}</h1> */}
-        <div className="pre-dropdown-container">
+        <div className="pre-dropdown-container" onClick={handleDropdown}>
           <div className="company-logo-div">
             <img className="company-logo" src={item.company_logo}></img>
           </div>
@@ -32,7 +32,9 @@ const MainJobBoardItem = ({ item }) => {
             </form>
           </div>
         </div>
-        {itemOpen && <h1>{item.job_description}</h1>}
+        {itemOpen && 
+          <div><h1>{item.job_description}</h1></div>
+        }
       </div>
     </React.Fragment>
   );


### PR DESCRIPTION
This PR fixes the overlapping text on the Job Board items for mobile, as well as moving the onClick to toggle the collapse function to the top div only (desktop / mobile). 